### PR TITLE
Added connected players method to API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+/target/

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 hs_err_pid*
 
 /target/
+.project
+.classpath
+.settings/

--- a/src/main/java/net/mcjukebox/plugin/bukkit/api/JukeboxAPI.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/api/JukeboxAPI.java
@@ -72,15 +72,16 @@ public class JukeboxAPI {
         params.put("username", player.getName());
         params.put("channel", channel);
         if(fadeDuration != -1) params.put("fadeDuration", fadeDuration);
-;        Bukkit.getScheduler().runTaskAsynchronously(MCJukebox.getInstance(), new Runnable() {
+
+       Bukkit.getScheduler().runTaskAsynchronously(MCJukebox.getInstance(), new Runnable() {
             public void run() {
                 MCJukebox.getInstance().getSocketHandler().emit("command/stopAll", params);
             }
         });
     }
 
-	/**
-	 * Gets the ShowManager instance currently in use. Note that show are a client side feature, implemented
+    /**
+     * Gets the ShowManager instance currently in use. Note that show are a client side feature, implemented
      * as as a higher level version of our internal channels system which allows multiple audio tracks
      * to be played simultaneously.
      *

--- a/src/main/java/net/mcjukebox/plugin/bukkit/api/JukeboxAPI.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/api/JukeboxAPI.java
@@ -24,6 +24,7 @@ public class JukeboxAPI {
         params.put("url", media.getURL());
         params.put("volume", media.getVolume());
         params.put("looping", media.isLooping());
+        params.put("continueTrack", media.isContinueTrack());
         params.put("channel", media.getChannel());
         if(media.getFadeDuration() != -1) params.put("fadeDuration", media.getFadeDuration());
         if(media.getStartTime() != -1) params.put("startTime", media.getStartTime());

--- a/src/main/java/net/mcjukebox/plugin/bukkit/api/JukeboxAPI.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/api/JukeboxAPI.java
@@ -7,6 +7,9 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.json.JSONObject;
 
+import java.util.Collections;
+import java.util.Set;
+
 public class JukeboxAPI {
 
     /**
@@ -89,6 +92,17 @@ public class JukeboxAPI {
      */
     public static ShowManager getShowManager() {
         return MCJukebox.getInstance().getShowManager();
+    }
+
+    /**
+     * Get an unmodifiable set of players who are connected to the audio server.
+     * <p>This set will be reset if the plugin is reloaded or restarted.
+     * <p>This set is for information purposes only and cannot be modified.
+     *
+     * @return an unmodifiable set of players
+     */
+    public static Set<Player> getConnectedPlayers() {
+        return Collections.unmodifiableSet(MCJukebox.getInstance().getSocketHandler().getConnectedPlayers());
     }
 
 }

--- a/src/main/java/net/mcjukebox/plugin/bukkit/api/models/Media.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/api/models/Media.java
@@ -13,7 +13,7 @@ public class Media {
 
     //The following options are only supported for the MUSIC resource type
     @Getter @Setter private int volume = 100;
-    @Getter @Setter private boolean looping = true;
+    @Getter @Setter private boolean looping = true, continueTrack = false;
     @Getter @Setter private int fadeDuration = -1;
     @Getter @Setter private long startTime = -1;
     @Getter @Setter private String channel = "default";
@@ -64,6 +64,12 @@ public class Media {
         if(options.has("channel")) {
             if(options.get("channel") instanceof String) {
                 this.channel = options.getString("channel");
+            }
+        }
+
+        if(options.has("continue")) {
+            if(options.get("continue") instanceof Boolean) {
+                continueTrack = options.getBoolean("continue");
             }
         }
     }

--- a/src/main/java/net/mcjukebox/plugin/bukkit/events/ClientConnectEvent.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/events/ClientConnectEvent.java
@@ -4,24 +4,33 @@ import lombok.Getter;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
+/**
+ * Event called when a player connects to the audio server
+ */
 public class ClientConnectEvent extends Event {
 
-	private static final HandlerList handlers = new HandlerList();
+    private static final HandlerList handlers = new HandlerList();
 
-	@Getter private String username;
-	@Getter private long timestamp;
+    /**
+     * Username of player who has connected
+     */
+    @Getter private final String username;
+    /**
+     * Timestamp of when they connected
+     */
+    @Getter private final long timestamp;
 
-	public ClientConnectEvent(String username, long timestamp) {
-		this.username = username;
-		this.timestamp = timestamp;
-	}
+    public ClientConnectEvent(String username, long timestamp) {
+        this.username = username;
+        this.timestamp = timestamp;
+    }
 
-	public HandlerList getHandlers() {
-		return handlers;
-	}
+    public HandlerList getHandlers() {
+        return handlers;
+    }
 
-	public static HandlerList getHandlerList() {
-		return handlers;
-	}
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
 
 }

--- a/src/main/java/net/mcjukebox/plugin/bukkit/events/ClientDisconnectEvent.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/events/ClientDisconnectEvent.java
@@ -4,24 +4,33 @@ import lombok.Getter;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
+/**
+ * Event called when a player disconnects from the audio server
+ */
 public class ClientDisconnectEvent extends Event {
 
-	private static final HandlerList handlers = new HandlerList();
+    private static final HandlerList handlers = new HandlerList();
 
-	@Getter private String username;
-	@Getter private long timestamp;
+    /**
+     * Username of player who has connected
+     */
+    @Getter private final String username;
+    /**
+     * Timestamp of when they connected
+     */
+    @Getter private final long timestamp;
 
-	public ClientDisconnectEvent(String username, long timestamp) {
-		this.username = username;
-		this.timestamp = timestamp;
-	}
+    public ClientDisconnectEvent(String username, long timestamp) {
+        this.username = username;
+        this.timestamp = timestamp;
+    }
 
-	public HandlerList getHandlers() {
-		return handlers;
-	}
+    public HandlerList getHandlers() {
+        return handlers;
+    }
 
-	public static HandlerList getHandlerList() {
-		return handlers;
-	}
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
 
 }

--- a/src/main/java/net/mcjukebox/plugin/bukkit/listeners/RegionListener.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/listeners/RegionListener.java
@@ -123,6 +123,8 @@ public class RegionListener implements Listener{
                 show.removeMember(event.getPlayer());
             }
         }
+
+        MCJukebox.getInstance().getSocketHandler().getConnectedPlayers().remove(event.getPlayer());
     }
 
 }

--- a/src/main/java/net/mcjukebox/plugin/bukkit/managers/LangManager.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/managers/LangManager.java
@@ -1,86 +1,83 @@
 package net.mcjukebox.plugin.bukkit.managers;
 
 import org.bukkit.ChatColor;
-import org.bukkit.plugin.Plugin;
 import org.json.JSONObject;
-
-import java.util.Iterator;
 
 public class LangManager {
 
-	private JSONObject keyValues = new JSONObject();
+    private JSONObject keyValues = new JSONObject();
 
-	public LangManager(){
-		addDefaults();
-	}
+    public LangManager(){
+        addDefaults();
+    }
 
-	/**
-	 * Loads the language file from the data folder, if it exists.
-	 */
-	public void loadLang(JSONObject langObject){
-		keyValues = langObject;
-		addDefaults();
-	}
+    /**
+     * Loads the language file from the data folder, if it exists.
+     */
+    public void loadLang(JSONObject langObject){
+        keyValues = langObject;
+        addDefaults();
+    }
 
-	/**
-	 * Returns the value associated with a particular key.
-	 *
-	 * @param key Key to find
-	 * @return Value from the config
-	 */
-	public String get(String key){
-		String[] elements = key.split("\\.");
-		JSONObject finalParent = keyValues;
+    /**
+     * Returns the value associated with a particular key.
+     *
+     * @param key Key to find
+     * @return Value from the config
+     */
+    public String get(String key){
+        String[] elements = key.split("\\.");
+        JSONObject finalParent = keyValues;
 
-		for(int i = 0; i < elements.length - 1; i++){
-			if(!finalParent.has(elements[i])) finalParent.put(elements[i], new JSONObject());
-			finalParent = finalParent.getJSONObject(elements[i]);
-		}
+        for(int i = 0; i < elements.length - 1; i++){
+            if(!finalParent.has(elements[i])) finalParent.put(elements[i], new JSONObject());
+            finalParent = finalParent.getJSONObject(elements[i]);
+        }
 
-		String value = null;
-		if(elements.length == 0 && finalParent.has(key)) value = finalParent.getString(key);
-		else if(finalParent.has(elements[elements.length - 1])) value = finalParent.getString(elements[elements.length - 1]);
+        String value = null;
+        if(elements.length == 0 && finalParent.has(key)) value = finalParent.getString(key);
+        else if(finalParent.has(elements[elements.length - 1])) value = finalParent.getString(elements[elements.length - 1]);
 
-		if(value != null) return ChatColor.translateAlternateColorCodes('&', value);
-		return ChatColor.RED + "Missing Key: " + key;
-	}
+        if(value != null) return ChatColor.translateAlternateColorCodes('&', value);
+        return ChatColor.RED + "Missing Key: " + key;
+    }
 
-	/**
-	 * Adds all default configuration values to the JSON Object.
-	 */
-	private void addDefaults(){
-		addDefault("region.registered", "&aRegion registered!");
-		addDefault("region.unregistered", "&aRegion unregistered!");
-		addDefault("region.notregistered", "&cThat region is not registered!");
+    /**
+     * Adds all default configuration values to the JSON Object.
+     */
+    private void addDefaults(){
+        addDefault("region.registered", "&aRegion registered!");
+        addDefault("region.unregistered", "&aRegion unregistered!");
+        addDefault("region.notregistered", "&cThat region is not registered!");
 
-		addDefault("user.openLoading", "&aGenerating link...");
-		addDefault("user.openClient", "Click here to launch our custom music client.");
-		addDefault("user.openHover", "Launch client");
-		addDefault("user.openDomain", "https://mcjukebox.net/client");
+        addDefault("user.openLoading", "&aGenerating link...");
+        addDefault("user.openClient", "Click here to launch our custom music client.");
+        addDefault("user.openHover", "Launch client");
+        addDefault("user.openDomain", "https://mcjukebox.net/client");
 
-		addDefault("event.clientConnect", "&aYou connected to our audio server!");
-		addDefault("event.clientDisconnect", "&cYou disconnected from our audio server.");
+        addDefault("event.clientConnect", "&aYou connected to our audio server!");
+        addDefault("event.clientDisconnect", "&cYou disconnected from our audio server.");
 
-		addDefault("command.notOnline", "&c[user] is not currently online.");
-	}
+        addDefault("command.notOnline", "&c[user] is not currently online.");
+    }
 
-	/**
-	 * Adds a particular property to the JSON Object if it is not already present.
-	 *
-	 * @param key Key to associate the value with
-	 * @param value Value to associate the key with
-	 */
-	private void addDefault(String key, String value){
-		String[] elements = key.split("\\.");
-		JSONObject finalParent = keyValues;
+    /**
+     * Adds a particular property to the JSON Object if it is not already present.
+     *
+     * @param key Key to associate the value with
+     * @param value Value to associate the key with
+     */
+    private void addDefault(String key, String value){
+        String[] elements = key.split("\\.");
+        JSONObject finalParent = keyValues;
 
-		for(int i = 0; i < elements.length - 1; i++){
-			if(!finalParent.has(elements[i])) finalParent.put(elements[i], new JSONObject());
-			finalParent = finalParent.getJSONObject(elements[i]);
-		}
+        for(int i = 0; i < elements.length - 1; i++){
+            if(!finalParent.has(elements[i])) finalParent.put(elements[i], new JSONObject());
+            finalParent = finalParent.getJSONObject(elements[i]);
+        }
 
-		if(!finalParent.has(key) && elements.length == 0) finalParent.put(key, value);
-		else if(!finalParent.has(elements[elements.length - 1])) finalParent.put(elements[elements.length - 1], value);
-	}
+        if(!finalParent.has(key) && elements.length == 0) finalParent.put(key, value);
+        else if(!finalParent.has(elements[elements.length - 1])) finalParent.put(elements[elements.length - 1], value);
+    }
 
 }

--- a/src/main/java/net/mcjukebox/plugin/bukkit/managers/shows/Show.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/managers/shows/Show.java
@@ -14,59 +14,59 @@ import java.util.UUID;
 
 public class Show {
 
-	@Getter private HashMap<UUID, Boolean> members = new HashMap<UUID, Boolean>();
-	@Getter private Media currentTrack;
-	@Getter @Setter private String channel = "default";
+    @Getter private HashMap<UUID, Boolean> members = new HashMap<UUID, Boolean>();
+    @Getter private Media currentTrack;
+    @Getter @Setter private String channel = "default";
 
-	public void addMember(Player player, boolean addedByRegion) {
-		if(members.containsKey(player.getUniqueId())) return;
-		members.put(player.getUniqueId(), addedByRegion);
+    public void addMember(Player player, boolean addedByRegion) {
+        if(members.containsKey(player.getUniqueId())) return;
+        members.put(player.getUniqueId(), addedByRegion);
 
-		if(currentTrack != null) JukeboxAPI.play(player, currentTrack);
-	}
+        if(currentTrack != null) JukeboxAPI.play(player, currentTrack);
+    }
 
-	public void removeMember(Player player) {
-		if(!members.containsKey(player.getUniqueId())) return;
-		members.remove(player.getUniqueId());
-		JukeboxAPI.stopAll(player, channel, -1);
-	}
+    public void removeMember(Player player) {
+        if(!members.containsKey(player.getUniqueId())) return;
+        members.remove(player.getUniqueId());
+        JukeboxAPI.stopAll(player, channel, -1);
+    }
 
-	public void play(Media media) {
-		media.setStartTime(MCJukebox.getInstance().getTimeUtils().currentTimeMillis());
-		media.setChannel(channel);
+    public void play(Media media) {
+        media.setStartTime(MCJukebox.getInstance().getTimeUtils().currentTimeMillis());
+        media.setChannel(channel);
 
-		if(media.getType() == ResourceType.MUSIC) {
-			currentTrack = media;
-		}
+        if(media.getType() == ResourceType.MUSIC) {
+            currentTrack = media;
+        }
 
-		for(UUID UUID : members.keySet()) {
-			if(Bukkit.getPlayer(UUID) == null) continue;
-			JukeboxAPI.play(Bukkit.getPlayer(UUID), media);
-		}
-	}
+        for(UUID UUID : members.keySet()) {
+            if(Bukkit.getPlayer(UUID) == null) continue;
+            JukeboxAPI.play(Bukkit.getPlayer(UUID), media);
+        }
+    }
 
-	public void stopMusic() {
-		stopMusic(-1);
-	}
+    public void stopMusic() {
+        stopMusic(-1);
+    }
 
-	public void stopMusic(int fadeDuration) {
-		if(currentTrack == null) return;
-		for(UUID UUID : members.keySet()) {
-			if(Bukkit.getPlayer(UUID) == null) continue;
-			JukeboxAPI.stopMusic(Bukkit.getPlayer(UUID), channel, fadeDuration);
-		}
-		currentTrack = null;
-	}
+    public void stopMusic(int fadeDuration) {
+        if(currentTrack == null) return;
+        for(UUID UUID : members.keySet()) {
+            if(Bukkit.getPlayer(UUID) == null) continue;
+            JukeboxAPI.stopMusic(Bukkit.getPlayer(UUID), channel, fadeDuration);
+        }
+        currentTrack = null;
+    }
 
-	public void stopAll() {
-		stopAll(-1);
-	}
+    public void stopAll() {
+        stopAll(-1);
+    }
 
-	public void stopAll(int fadeDuration) {
-		for(UUID UUID : members.keySet()) {
-			if(Bukkit.getPlayer(UUID) == null) continue;
-			JukeboxAPI.stopAll(Bukkit.getPlayer(UUID), channel, fadeDuration);
-		}
-	}
+    public void stopAll(int fadeDuration) {
+        for(UUID UUID : members.keySet()) {
+            if(Bukkit.getPlayer(UUID) == null) continue;
+            JukeboxAPI.stopAll(Bukkit.getPlayer(UUID), channel, fadeDuration);
+        }
+    }
 
 }

--- a/src/main/java/net/mcjukebox/plugin/bukkit/managers/shows/ShowManager.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/managers/shows/ShowManager.java
@@ -9,37 +9,37 @@ import java.util.UUID;
 
 public class ShowManager {
 
-	@Getter private HashMap<String, Show> shows = new HashMap<String, Show>();
+    @Getter private HashMap<String, Show> shows = new HashMap<String, Show>();
 
-	public Show getShow(String name) {
-		name = name.replace("@", "");
-		name = name.toLowerCase();
-		if(shows.containsKey(name)) return shows.get(name);
+    public Show getShow(String name) {
+        name = name.replace("@", "");
+        name = name.toLowerCase();
+        if(shows.containsKey(name)) return shows.get(name);
 
-		Show show = new Show();
-		show.setChannel(name);
-		shows.put(name, show);
-		return show;
-	}
+        Show show = new Show();
+        show.setChannel(name);
+        shows.put(name, show);
+        return show;
+    }
 
-	public List<Show> getShowsByPlayer(UUID UUID) {
-		ArrayList<Show> inShows = new ArrayList<Show>();
-		for(Show show : shows.values()) {
-			if(show.getMembers().containsKey(UUID)) inShows.add(show);
-		}
-		return inShows;
-	}
+    public List<Show> getShowsByPlayer(UUID UUID) {
+        ArrayList<Show> inShows = new ArrayList<Show>();
+        for(Show show : shows.values()) {
+            if(show.getMembers().containsKey(UUID)) inShows.add(show);
+        }
+        return inShows;
+    }
 
-	public boolean inInShow(UUID UUID) {
-		for(Show show : shows.values()) {
-			if(show.getMembers().containsKey(UUID)) return true;
-		}
-		return false;
-	}
+    public boolean inInShow(UUID UUID) {
+        for(Show show : shows.values()) {
+            if(show.getMembers().containsKey(UUID)) return true;
+        }
+        return false;
+    }
 
-	public boolean showExists(String name) {
-		name = name.replace("@", "");
-		return shows.containsKey(name);
-	}
+    public boolean showExists(String name) {
+        name = name.replace("@", "");
+        return shows.containsKey(name);
+    }
 
 }

--- a/src/main/java/net/mcjukebox/plugin/bukkit/sockets/KeyHandler.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/sockets/KeyHandler.java
@@ -1,6 +1,5 @@
 package net.mcjukebox.plugin.bukkit.sockets;
 
-import io.socket.emitter.Emitter;
 import lombok.Getter;
 import net.mcjukebox.plugin.bukkit.MCJukebox;
 import net.mcjukebox.plugin.bukkit.utils.DataUtils;
@@ -13,29 +12,29 @@ import java.io.File;
 
 public class KeyHandler {
 
-	private SocketHandler socketHandler;
-	@Getter private CommandSender currentlyTryingKey;
+    private SocketHandler socketHandler;
+    @Getter private CommandSender currentlyTryingKey;
 
-	public KeyHandler(SocketHandler socketHandler) {
-		this.socketHandler = socketHandler;
-	}
+    public KeyHandler(SocketHandler socketHandler) {
+        this.socketHandler = socketHandler;
+    }
 
-	public void onKeyRejected(String reason) {
-		CommandSender toNotify = currentlyTryingKey != null ? currentlyTryingKey : Bukkit.getConsoleSender();
-		toNotify.sendMessage(ChatColor.RED + "API key rejected with message: " + reason);
-		deleteKey();
-		currentlyTryingKey = null;
-	}
+    public void onKeyRejected(String reason) {
+        CommandSender toNotify = currentlyTryingKey != null ? currentlyTryingKey : Bukkit.getConsoleSender();
+        toNotify.sendMessage(ChatColor.RED + "API key rejected with message: " + reason);
+        deleteKey();
+        currentlyTryingKey = null;
+    }
 
-	public void tryKey(@Nullable CommandSender sender, String key) {
-		currentlyTryingKey = sender;
-		DataUtils.saveObjectToPath(key, MCJukebox.getInstance().getDataFolder() + "/api.key");
-		socketHandler.disconnect();
-		socketHandler.attemptConnection();
-	}
+    public void tryKey(@Nullable CommandSender sender, String key) {
+        currentlyTryingKey = sender;
+        DataUtils.saveObjectToPath(key, MCJukebox.getInstance().getDataFolder() + "/api.key");
+        socketHandler.disconnect();
+        socketHandler.attemptConnection();
+    }
 
-	private void deleteKey() {
-		new File(MCJukebox.getInstance().getDataFolder() + "/api.key").delete();
-	}
+    private void deleteKey() {
+        new File(MCJukebox.getInstance().getDataFolder() + "/api.key").delete();
+    }
 
 }

--- a/src/main/java/net/mcjukebox/plugin/bukkit/sockets/ReconnectTask.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/sockets/ReconnectTask.java
@@ -1,49 +1,47 @@
 package net.mcjukebox.plugin.bukkit.sockets;
 
 import lombok.Setter;
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 
 import java.util.Random;
 
 public class ReconnectTask implements Runnable {
 
-	private SocketHandler socketHandler;
-	private long lastReconnectionAttempt = 0;
-	private int reconnectionFailures = 0;
-	@Setter private boolean reconnecting = true;
+    private SocketHandler socketHandler;
+    private long lastReconnectionAttempt = 0;
+    private int reconnectionFailures = 0;
+    @Setter private boolean reconnecting = true;
 
-	public ReconnectTask(SocketHandler socketHandler) {
-		this.socketHandler = socketHandler;
-	}
+    public ReconnectTask(SocketHandler socketHandler) {
+        this.socketHandler = socketHandler;
+    }
 
-	@Override
-	public void run() {
-		if(reconnecting || socketHandler.getServer().connected()) return;
-		long timeSinceRun = System.currentTimeMillis() - lastReconnectionAttempt;
-		if(timeSinceRun < getCurrentReconnectionDelay(reconnectionFailures)) return;
+    @Override
+    public void run() {
+        if(reconnecting || socketHandler.getServer().connected()) return;
+        long timeSinceRun = System.currentTimeMillis() - lastReconnectionAttempt;
+        if(timeSinceRun < getCurrentReconnectionDelay(reconnectionFailures)) return;
 
-		//Add some randomness to reconnect interval to prevent server overload
-		if(new Random().nextInt(15) != 7) return;
+        //Add some randomness to reconnect interval to prevent server overload
+        if(new Random().nextInt(15) != 7) return;
 
-		reconnecting = true;
-		reconnectionFailures = reconnectionFailures + 1;
-		lastReconnectionAttempt = System.currentTimeMillis();
+        reconnecting = true;
+        reconnectionFailures = reconnectionFailures + 1;
+        lastReconnectionAttempt = System.currentTimeMillis();
 
-		socketHandler.attemptConnection();
-	}
+        socketHandler.attemptConnection();
+    }
 
-	public void reset() {
-		lastReconnectionAttempt = 0;
-		reconnectionFailures = 0;
-		reconnecting = false;
-	}
+    public void reset() {
+        lastReconnectionAttempt = 0;
+        reconnectionFailures = 0;
+        reconnecting = false;
+    }
 
-	private int getCurrentReconnectionDelay(int reconnectionFailures) {
-		if(reconnectionFailures <= 3) return 3 * 1000;
-		if(reconnectionFailures <= 6) return 15 * 1000;
-		if(reconnectionFailures <= 8) return 30 * 1000;
-		return 2 * 60 * 1000;
-	}
+    private int getCurrentReconnectionDelay(int reconnectionFailures) {
+        if(reconnectionFailures <= 3) return 3 * 1000;
+        if(reconnectionFailures <= 6) return 15 * 1000;
+        if(reconnectionFailures <= 8) return 30 * 1000;
+        return 2 * 60 * 1000;
+    }
 
 }

--- a/src/main/java/net/mcjukebox/plugin/bukkit/sockets/SocketHandler.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/sockets/SocketHandler.java
@@ -1,10 +1,10 @@
 package net.mcjukebox.plugin.bukkit.sockets;
 
+import io.socket.client.IO;
+import io.socket.client.Socket;
 import lombok.Getter;
 import net.mcjukebox.plugin.bukkit.MCJukebox;
 import net.mcjukebox.plugin.bukkit.sockets.listeners.*;
-import io.socket.client.IO;
-import io.socket.client.Socket;
 import org.bukkit.Bukkit;
 import org.json.JSONObject;
 

--- a/src/main/java/net/mcjukebox/plugin/bukkit/sockets/SocketHandler.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/sockets/SocketHandler.java
@@ -6,9 +6,12 @@ import lombok.Getter;
 import net.mcjukebox.plugin.bukkit.MCJukebox;
 import net.mcjukebox.plugin.bukkit.sockets.listeners.*;
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.json.JSONObject;
 
 import javax.annotation.Nullable;
+import java.util.HashSet;
+import java.util.Set;
 
 public class SocketHandler {
 
@@ -17,6 +20,13 @@ public class SocketHandler {
 	@Getter private DropListener dropListener = new DropListener();
 	@Getter private KeyHandler keyHandler = new KeyHandler(this);
 	@Getter private ConnectionListener connectionListener = new ConnectionListener(this);
+
+    /**
+     * Set containing players who have the audio server open
+     * <p>This set should ONLY be modified from within the
+     * Jukebox plugin to avoid conflicts or concurrency issues.
+     */
+	@Getter private Set<Player> connectedPlayers = new HashSet<Player>();
 
 	public SocketHandler() {
 		reconnectTask = new ReconnectTask(this);

--- a/src/main/java/net/mcjukebox/plugin/bukkit/sockets/listeners/ClientConnectListener.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/sockets/listeners/ClientConnectListener.java
@@ -13,24 +13,24 @@ import org.json.JSONObject;
 
 public class ClientConnectListener implements Emitter.Listener {
 
-	@Override
-	public void call(Object... objects) {
-		JSONObject data = (JSONObject) objects[0];
-		ClientConnectEvent event = new ClientConnectEvent(
-				data.getString("username"), data.getLong("timestamp"));
-		MCJukebox.getInstance().getServer().getPluginManager().callEvent(event);
+    @Override
+    public void call(Object... objects) {
+        JSONObject data = (JSONObject) objects[0];
+        ClientConnectEvent event = new ClientConnectEvent(
+                data.getString("username"), data.getLong("timestamp"));
+        MCJukebox.getInstance().getServer().getPluginManager().callEvent(event);
 
-		if(Bukkit.getPlayer(data.getString("username")) == null) return;
-		Player player = Bukkit.getPlayer(data.getString("username"));
-		MessageUtils.sendMessage(player, "event.clientConnect");
+        if(Bukkit.getPlayer(data.getString("username")) == null) return;
+        Player player = Bukkit.getPlayer(data.getString("username"));
+        MessageUtils.sendMessage(player, "event.clientConnect");
 
-		ShowManager showManager = MCJukebox.getInstance().getShowManager();
-		if(!showManager.inInShow(player.getUniqueId())) return;
+        ShowManager showManager = MCJukebox.getInstance().getShowManager();
+        if(!showManager.inInShow(player.getUniqueId())) return;
 
-		for(Show show : showManager.getShowsByPlayer(player.getUniqueId())) {
-			if(show.getCurrentTrack() != null)
-				JukeboxAPI.play(player, show.getCurrentTrack());
-		}
-	}
+        for(Show show : showManager.getShowsByPlayer(player.getUniqueId())) {
+            if(show.getCurrentTrack() != null)
+                JukeboxAPI.play(player, show.getCurrentTrack());
+        }
+    }
 
 }

--- a/src/main/java/net/mcjukebox/plugin/bukkit/sockets/listeners/ClientConnectListener.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/sockets/listeners/ClientConnectListener.java
@@ -24,6 +24,8 @@ public class ClientConnectListener implements Emitter.Listener {
         Player player = Bukkit.getPlayer(data.getString("username"));
         MessageUtils.sendMessage(player, "event.clientConnect");
 
+        MCJukebox.getInstance().getSocketHandler().getConnectedPlayers().add(Bukkit.getPlayer(data.getString("username")));
+
         ShowManager showManager = MCJukebox.getInstance().getShowManager();
         if(!showManager.inInShow(player.getUniqueId())) return;
 

--- a/src/main/java/net/mcjukebox/plugin/bukkit/sockets/listeners/ClientDisconnectListener.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/sockets/listeners/ClientDisconnectListener.java
@@ -18,6 +18,8 @@ public class ClientDisconnectListener implements Emitter.Listener {
 
         if(Bukkit.getPlayer(data.getString("username")) == null) return;
         MessageUtils.sendMessage(Bukkit.getPlayer(data.getString("username")), "event.clientDisconnect");
+
+        MCJukebox.getInstance().getSocketHandler().getConnectedPlayers().remove(Bukkit.getPlayer(data.getString("username")));
     }
 
 }

--- a/src/main/java/net/mcjukebox/plugin/bukkit/sockets/listeners/ClientDisconnectListener.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/sockets/listeners/ClientDisconnectListener.java
@@ -2,27 +2,22 @@ package net.mcjukebox.plugin.bukkit.sockets.listeners;
 
 import io.socket.emitter.Emitter;
 import net.mcjukebox.plugin.bukkit.MCJukebox;
-import net.mcjukebox.plugin.bukkit.api.JukeboxAPI;
-import net.mcjukebox.plugin.bukkit.events.ClientConnectEvent;
 import net.mcjukebox.plugin.bukkit.events.ClientDisconnectEvent;
-import net.mcjukebox.plugin.bukkit.managers.shows.Show;
-import net.mcjukebox.plugin.bukkit.managers.shows.ShowManager;
 import net.mcjukebox.plugin.bukkit.utils.MessageUtils;
 import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
 import org.json.JSONObject;
 
 public class ClientDisconnectListener implements Emitter.Listener {
 
-	@Override
-	public void call(Object... objects) {
-		JSONObject data = (JSONObject) objects[0];
-		ClientDisconnectEvent event = new ClientDisconnectEvent(
-				data.getString("username"), data.getLong("timestamp"));
-		MCJukebox.getInstance().getServer().getPluginManager().callEvent(event);
+    @Override
+    public void call(Object... objects) {
+        JSONObject data = (JSONObject) objects[0];
+        ClientDisconnectEvent event = new ClientDisconnectEvent(
+                data.getString("username"), data.getLong("timestamp"));
+        MCJukebox.getInstance().getServer().getPluginManager().callEvent(event);
 
-		if(Bukkit.getPlayer(data.getString("username")) == null) return;
-		MessageUtils.sendMessage(Bukkit.getPlayer(data.getString("username")), "event.clientDisconnect");
-	}
+        if(Bukkit.getPlayer(data.getString("username")) == null) return;
+        MessageUtils.sendMessage(Bukkit.getPlayer(data.getString("username")), "event.clientDisconnect");
+    }
 
 }

--- a/src/main/java/net/mcjukebox/plugin/bukkit/sockets/listeners/ConnectionListener.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/sockets/listeners/ConnectionListener.java
@@ -16,76 +16,76 @@ import java.util.List;
 
 public class ConnectionListener {
 
-	@Getter private ConnectionFailedListener connectionFailedListener;
-	@Getter private ConnectionSuccessListener connectionSuccessListener;
+    @Getter private ConnectionFailedListener connectionFailedListener;
+    @Getter private ConnectionSuccessListener connectionSuccessListener;
 
-	private SocketHandler socketHandler;
-	private HashMap<String, List<JSONObject>> queue = new HashMap<String, List<JSONObject>>();
-	private boolean noConnectionWarned = false;
+    private SocketHandler socketHandler;
+    private HashMap<String, List<JSONObject>> queue = new HashMap<String, List<JSONObject>>();
+    private boolean noConnectionWarned = false;
 
-	public ConnectionListener(SocketHandler socketHandler) {
-		this.socketHandler = socketHandler;
-		connectionFailedListener = new ConnectionFailedListener();
-		connectionSuccessListener = new ConnectionSuccessListener(socketHandler.getDropListener());
-	}
+    public ConnectionListener(SocketHandler socketHandler) {
+        this.socketHandler = socketHandler;
+        connectionFailedListener = new ConnectionFailedListener();
+        connectionSuccessListener = new ConnectionSuccessListener(socketHandler.getDropListener());
+    }
 
-	public class ConnectionFailedListener implements Emitter.Listener {
+    public class ConnectionFailedListener implements Emitter.Listener {
 
-		@Override
-		public void call(Object... objects) {
-			String reason = objects.length > 0 && objects[0] instanceof String ? (String) objects[0] : null;
+        @Override
+        public void call(Object... objects) {
+            String reason = objects.length > 0 && objects[0] instanceof String ? (String) objects[0] : null;
 
-			if(reason != null) {
-				socketHandler.getKeyHandler().onKeyRejected(reason);
-				return;
-			}
+            if(reason != null) {
+                socketHandler.getKeyHandler().onKeyRejected(reason);
+                return;
+            }
 
-			socketHandler.getReconnectTask().setReconnecting(false);
-			if(noConnectionWarned) return;
+            socketHandler.getReconnectTask().setReconnecting(false);
+            if(noConnectionWarned) return;
 
-			CommandSender recipient = socketHandler.getKeyHandler().getCurrentlyTryingKey();
-			if(recipient == null) recipient = Bukkit.getConsoleSender();
-			recipient.sendMessage(ChatColor.RED + "Unable to connect to MCJukebox.");
-			recipient.sendMessage(ChatColor.RED + "This could be caused by a period of server maintenance.");
-			recipient.sendMessage(ChatColor.GOLD + "If the problem persists, please email support@mcjukebox.net");
-			noConnectionWarned = true;
-		}
+            CommandSender recipient = socketHandler.getKeyHandler().getCurrentlyTryingKey();
+            if(recipient == null) recipient = Bukkit.getConsoleSender();
+            recipient.sendMessage(ChatColor.RED + "Unable to connect to MCJukebox.");
+            recipient.sendMessage(ChatColor.RED + "This could be caused by a period of server maintenance.");
+            recipient.sendMessage(ChatColor.GOLD + "If the problem persists, please email support@mcjukebox.net");
+            noConnectionWarned = true;
+        }
 
-	}
+    }
 
-	@AllArgsConstructor
-	public class ConnectionSuccessListener implements Emitter.Listener {
+    @AllArgsConstructor
+    public class ConnectionSuccessListener implements Emitter.Listener {
 
-		private DropListener dropListener;
+        private DropListener dropListener;
 
-		@Override
-		public void call(Object... objects) {
-			CommandSender recipient = socketHandler.getKeyHandler().getCurrentlyTryingKey();
-			String message = "Key accepted and connection to MCJukebox established.";
+        @Override
+        public void call(Object... objects) {
+            CommandSender recipient = socketHandler.getKeyHandler().getCurrentlyTryingKey();
+            String message = "Key accepted and connection to MCJukebox established.";
 
-			if(recipient != null) recipient.sendMessage(ChatColor.GREEN + message);
-			else MCJukebox.getInstance().getLogger().info(message);
+            if(recipient != null) recipient.sendMessage(ChatColor.GREEN + message);
+            else MCJukebox.getInstance().getLogger().info(message);
 
-			dropListener.setLastDripSent(System.currentTimeMillis());
-			socketHandler.emit("drip", null);
+            dropListener.setLastDripSent(System.currentTimeMillis());
+            socketHandler.emit("drip", null);
 
-			for(String channel : queue.keySet()) {
-				for(JSONObject params : queue.get(channel)) {
-					socketHandler.emit(channel, params);
-				}
-			}
+            for(String channel : queue.keySet()) {
+                for(JSONObject params : queue.get(channel)) {
+                    socketHandler.emit(channel, params);
+                }
+            }
 
-			queue.clear();
-			noConnectionWarned = false;
-			socketHandler.getReconnectTask().reset();
-		}
+            queue.clear();
+            noConnectionWarned = false;
+            socketHandler.getReconnectTask().reset();
+        }
 
-	}
+    }
 
-	public void addToQueue(String channel, JSONObject params) {
-		List<JSONObject> toRun = queue.containsKey(channel) ? queue.get(channel) : new ArrayList<JSONObject>();
-		toRun.add(params);
-		queue.put(channel, toRun);
-	}
+    public void addToQueue(String channel, JSONObject params) {
+        List<JSONObject> toRun = queue.containsKey(channel) ? queue.get(channel) : new ArrayList<JSONObject>();
+        toRun.add(params);
+        queue.put(channel, toRun);
+    }
 
 }

--- a/src/main/java/net/mcjukebox/plugin/bukkit/sockets/listeners/DropListener.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/sockets/listeners/DropListener.java
@@ -6,13 +6,13 @@ import net.mcjukebox.plugin.bukkit.MCJukebox;
 
 public class DropListener implements Emitter.Listener {
 
-	@Setter private long lastDripSent;
+    @Setter private long lastDripSent;
 
-	@Override
-	public void call(Object... objects) {
-		long roundTripTime = System.currentTimeMillis() - lastDripSent;
-		long serverTime = (long) objects[0];
-		MCJukebox.getInstance().getTimeUtils().updateOffset(roundTripTime, serverTime);
-	}
+    @Override
+    public void call(Object... objects) {
+        long roundTripTime = System.currentTimeMillis() - lastDripSent;
+        long serverTime = (long) objects[0];
+        MCJukebox.getInstance().getTimeUtils().updateOffset(roundTripTime, serverTime);
+    }
 
 }

--- a/src/main/java/net/mcjukebox/plugin/bukkit/sockets/listeners/LangListener.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/sockets/listeners/LangListener.java
@@ -6,10 +6,10 @@ import org.json.JSONObject;
 
 public class LangListener implements Emitter.Listener {
 
-	@Override
-	public void call(Object... objects) {
-		JSONObject data = (JSONObject) (objects.length == 2 ? objects[1] : objects[0]);
-		MCJukebox.getInstance().getLangManager().loadLang(data);
-	}
+    @Override
+    public void call(Object... objects) {
+        JSONObject data = (JSONObject) (objects.length == 2 ? objects[1] : objects[0]);
+        MCJukebox.getInstance().getLangManager().loadLang(data);
+    }
 
 }

--- a/src/main/java/net/mcjukebox/plugin/bukkit/sockets/listeners/TokenListener.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/sockets/listeners/TokenListener.java
@@ -8,11 +8,11 @@ import org.json.JSONObject;
 
 public class TokenListener implements Emitter.Listener {
 
-	@Override
-	public void call(Object... objects) {
-		JSONObject data = (JSONObject) objects[0];
-		Player linkFor = Bukkit.getPlayer(data.getString("username"));
-		if(linkFor == null) return;
-		MessageUtils.sendURL(linkFor, data.getString("token"));
-	}
+    @Override
+    public void call(Object... objects) {
+        JSONObject data = (JSONObject) objects[0];
+        Player linkFor = Bukkit.getPlayer(data.getString("username"));
+        if(linkFor == null) return;
+        MessageUtils.sendURL(linkFor, data.getString("token"));
+    }
 }

--- a/src/main/java/net/mcjukebox/plugin/bukkit/utils/MessageUtils.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/utils/MessageUtils.java
@@ -10,57 +10,57 @@ import java.util.HashMap;
 
 public class MessageUtils {
 
-	@Setter private static LangManager langManager;
+    @Setter private static LangManager langManager;
 
-	/**
-	 * Sends a message to the given player.
-	 *
-	 * @param player Player who the message should be sent to
-	 * @param key Key which should be used to lookup the message
-	 */
-	public static void sendMessage(CommandSender player, String key){
-		sendMessage(player, key, null);
-	}
+    /**
+     * Sends a message to the given player.
+     *
+     * @param player Player who the message should be sent to
+     * @param key Key which should be used to lookup the message
+     */
+    public static void sendMessage(CommandSender player, String key){
+        sendMessage(player, key, null);
+    }
 
-	/**
-	 * Sends a message to the given player, replacing particular keys.
-	 *
-	 * @param player Player who the message should be sent to
-	 * @param key Key which should be used to lookup the message
-	 * @param findAndReplace Optional list of keys which should be replaced with the corresponding values
-	 */
-	public static void sendMessage(CommandSender player, String key, HashMap<String, String> findAndReplace){
-		String message = langManager.get(key);
+    /**
+     * Sends a message to the given player, replacing particular keys.
+     *
+     * @param player Player who the message should be sent to
+     * @param key Key which should be used to lookup the message
+     * @param findAndReplace Optional list of keys which should be replaced with the corresponding values
+     */
+    public static void sendMessage(CommandSender player, String key, HashMap<String, String> findAndReplace){
+        String message = langManager.get(key);
 
-		//Don't send message if the localisation is blank
-		if(message.trim().equalsIgnoreCase("")) return;
+        //Don't send message if the localisation is blank
+        if(message.trim().equalsIgnoreCase("")) return;
 
-		//Replace any values in the find and replace HashMap, if it is present
-		message = ChatColor.translateAlternateColorCodes('&', message);
-		if (findAndReplace != null) {
-			for (String find : findAndReplace.keySet()) message = message.replace("[" + find + "]", findAndReplace.get(find));
-		}
+        //Replace any values in the find and replace HashMap, if it is present
+        message = ChatColor.translateAlternateColorCodes('&', message);
+        if (findAndReplace != null) {
+            for (String find : findAndReplace.keySet()) message = message.replace("[" + find + "]", findAndReplace.get(find));
+        }
 
-		player.sendMessage(message);
-	}
+        player.sendMessage(message);
+    }
 
-	public static void sendURL(Player player, String token){
-		if(isSpigot()){
-			new SpigotUtils().URL(player, langManager, token);
-		}else{
-			String URL = langManager.get("user.openDomain") + "?token=" + token;
-			player.sendMessage(ChatColor.GOLD + langManager.get("user.openClient"));
-			player.sendMessage(ChatColor.GOLD + URL);
-		}
-	}
+    public static void sendURL(Player player, String token){
+        if(isSpigot()){
+            new SpigotUtils().URL(player, langManager, token);
+        }else{
+            String URL = langManager.get("user.openDomain") + "?token=" + token;
+            player.sendMessage(ChatColor.GOLD + langManager.get("user.openClient"));
+            player.sendMessage(ChatColor.GOLD + URL);
+        }
+    }
 
-	private static boolean isSpigot(){
-		try {
-			Class.forName("net.md_5.bungee.api.chat.TextComponent");
-			return true;
-		} catch(Exception e) {
-			return false;
-		}
-	}
+    private static boolean isSpigot(){
+        try {
+            Class.forName("net.md_5.bungee.api.chat.TextComponent");
+            return true;
+        } catch(Exception e) {
+            return false;
+        }
+    }
 
 }

--- a/src/main/java/net/mcjukebox/plugin/bukkit/utils/SpigotUtils.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/utils/SpigotUtils.java
@@ -7,13 +7,13 @@ import org.bukkit.entity.Player;
 
 public class SpigotUtils {
 
-	public static void URL(Player player, LangManager langManager, String token){
-		String URL = langManager.get("user.openDomain") + "?token=" + token;
+    public static void URL(Player player, LangManager langManager, String token){
+        String URL = langManager.get("user.openDomain") + "?token=" + token;
 
-		TextComponent message = new TextComponent(TextComponent.fromLegacyText(langManager.get("user.openClient")));
-		message.setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, URL));
-		message.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText(langManager.get("user.openHover"))));
-		player.spigot().sendMessage(message);
-	}
+        TextComponent message = new TextComponent(TextComponent.fromLegacyText(langManager.get("user.openClient")));
+        message.setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, URL));
+        message.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText(langManager.get("user.openHover"))));
+        player.spigot().sendMessage(message);
+    }
 
 }

--- a/src/main/java/net/mcjukebox/plugin/bukkit/utils/TimeUtils.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/utils/TimeUtils.java
@@ -4,25 +4,25 @@ import net.mcjukebox.plugin.bukkit.MCJukebox;
 
 public class TimeUtils {
 
-	private static boolean hasUpdated = false;
-	private static long offset = 0;
+    private static boolean hasUpdated = false;
+    private static long offset = 0;
 
-	public boolean hasUpdated() {
-		return hasUpdated;
-	}
+    public boolean hasUpdated() {
+        return hasUpdated;
+    }
 
-	public void updateOffset(long roundTripTime, long serverTime) {
-		long offsetFromServer = roundTripTime / 2;
-		long estimatedTime = serverTime + offsetFromServer;
+    public void updateOffset(long roundTripTime, long serverTime) {
+        long offsetFromServer = roundTripTime / 2;
+        long estimatedTime = serverTime + offsetFromServer;
 
-		offset = estimatedTime - System.currentTimeMillis();
-		hasUpdated = true;
+        offset = estimatedTime - System.currentTimeMillis();
+        hasUpdated = true;
 
-		MCJukebox.getInstance().getLogger().info("Predicted time offset: " + offset + "ms.");
-	}
+        MCJukebox.getInstance().getLogger().info("Predicted time offset: " + offset + "ms.");
+    }
 
-	public long currentTimeMillis() {
-		return System.currentTimeMillis() + offset;
-	}
+    public long currentTimeMillis() {
+        return System.currentTimeMillis() + offset;
+    }
 
 }


### PR DESCRIPTION
This is a workaround so that plugins can see who has the audio client
open.
The API method is unmodifiable to avoid concurrency issues or conflicts.

It keeps track of connect and disconnect events and adds them to a set.
In the future it would be best to handle this from the backend audio
server and redis for persistence.

I also formatted everything using spaces instead of tabs for indents at a width of 4.
Before I did that some files were using tabs and others were using spaces, this makes it more uniform 👍 