### PR TITLE
Fixes #22

### DIFF
--- a/src/main/java/net/mcjukebox/plugin/bukkit/listeners/RegionListener.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/listeners/RegionListener.java
@@ -80,7 +80,7 @@ public class RegionListener implements Listener{
                 String lastShow = utils.getURL(playerInRegion.get(e.getPlayer().getUniqueId()));
                 playerInRegion.remove(e.getPlayer().getUniqueId());
 
-                if (lastShow == null) {
+                if (lastShow == null || lastShow.toCharArray()[0] != '@') {
                     //Region no longer exists, stop the music.
                     JukeboxAPI.stopMusic(e.getPlayer());
                     return;

--- a/src/main/java/net/mcjukebox/plugin/bukkit/listeners/RegionListener.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/listeners/RegionListener.java
@@ -83,10 +83,7 @@ public class RegionListener implements Listener{
                 if (lastShow == null) {
                     //Region no longer exists, stop the music.
                     JukeboxAPI.stopMusic(e.getPlayer());
-                    return;
-                }
-
-                if(lastShow.toCharArray()[0] == '@') {
+                } else if(lastShow.toCharArray()[0] == '@') {
                     showManager.getShow(lastShow).removeMember(e.getPlayer());
                     return;
                 }
@@ -127,13 +124,10 @@ public class RegionListener implements Listener{
         if(playerInRegion.containsKey(event.getPlayer().getUniqueId())) {
             String lastAudio = utils.getURL(playerInRegion.get(event.getPlayer().getUniqueId()));
 
-            if (lastAudio == null) {
-                //If null, region no longer exists - stop the music.
+            if(lastAudio == null || lastAudio.toCharArray()[0] != '@') {
                 JukeboxAPI.stopMusic(event.getPlayer());
-                return;
             }
 
-            if(lastAudio.toCharArray()[0] != '@') JukeboxAPI.stopMusic(event.getPlayer());
             playerInRegion.remove(event.getPlayer().getUniqueId());
         }
 

--- a/src/main/java/net/mcjukebox/plugin/bukkit/listeners/RegionListener.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/listeners/RegionListener.java
@@ -83,12 +83,11 @@ public class RegionListener implements Listener{
                 if (lastShow == null) {
                     //Region no longer exists, stop the music.
                     JukeboxAPI.stopMusic(e.getPlayer());
+                    return;
                 } else if(lastShow.toCharArray()[0] == '@') {
                     showManager.getShow(lastShow).removeMember(e.getPlayer());
                     return;
                 }
-
-                JukeboxAPI.stopMusic(e.getPlayer());
             }
             return;
         }

--- a/src/main/java/net/mcjukebox/plugin/bukkit/listeners/RegionListener.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/listeners/RegionListener.java
@@ -80,6 +80,12 @@ public class RegionListener implements Listener{
                 String lastShow = utils.getURL(playerInRegion.get(e.getPlayer().getUniqueId()));
                 playerInRegion.remove(e.getPlayer().getUniqueId());
 
+                if (lastShow == null) {
+                    //Region no longer exists, stop the music.
+                    JukeboxAPI.stopMusic(e.getPlayer());
+                    return;
+                }
+
                 if(lastShow.toCharArray()[0] == '@') {
                     showManager.getShow(lastShow).removeMember(e.getPlayer());
                     return;
@@ -120,6 +126,13 @@ public class RegionListener implements Listener{
     public void onLeave(PlayerQuitEvent event){
         if(playerInRegion.containsKey(event.getPlayer().getUniqueId())) {
             String lastAudio = utils.getURL(playerInRegion.get(event.getPlayer().getUniqueId()));
+
+            if (lastAudio == null) {
+                //If null, region no longer exists - stop the music.
+                JukeboxAPI.stopMusic(event.getPlayer());
+                return;
+            }
+
             if(lastAudio.toCharArray()[0] != '@') JukeboxAPI.stopMusic(event.getPlayer());
             playerInRegion.remove(event.getPlayer().getUniqueId());
         }

--- a/src/main/java/net/mcjukebox/plugin/bukkit/managers/RegionManager.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/managers/RegionManager.java
@@ -39,19 +39,18 @@ public class RegionManager implements Listener {
         ShowManager showManager = MCJukebox.getInstance().getShowManager();
         HashMap<UUID, String> playersInRegion = MCJukebox.getInstance().getRegionListener().getPlayerInRegion();
 
-        for (HashMap.Entry<UUID, String> entry: playersInRegion.entrySet()) {
+        for (HashMap.Entry<UUID, String> entry : playersInRegion.entrySet()) {
             UUID uuid = entry.getKey();
             String regionID = entry.getValue();
 
             if (regionID.equals(ID)) {
-
                 if (regions.get(ID).charAt(0) == '@') {
                     showManager.getShow(regions.get(ID)).removeMember(Bukkit.getPlayer(uuid));
                 } else {
                     JukeboxAPI.stopMusic(Bukkit.getPlayer(uuid));
+                    playersInRegion.remove(uuid);
                 }
             }
-
         }
         regions.remove(ID);
     }

--- a/src/main/java/net/mcjukebox/plugin/bukkit/managers/RegionManager.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/managers/RegionManager.java
@@ -9,6 +9,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.event.Listener;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 public class RegionManager implements Listener {
@@ -39,7 +40,7 @@ public class RegionManager implements Listener {
         ShowManager showManager = MCJukebox.getInstance().getShowManager();
         HashMap<UUID, String> playersInRegion = MCJukebox.getInstance().getRegionListener().getPlayerInRegion();
 
-        for (HashMap.Entry<UUID, String> entry : playersInRegion.entrySet()) {
+        for (Map.Entry<UUID, String> entry : playersInRegion.entrySet()) {
             UUID uuid = entry.getKey();
             String regionID = entry.getValue();
 

--- a/src/main/java/net/mcjukebox/plugin/bukkit/managers/RegionManager.java
+++ b/src/main/java/net/mcjukebox/plugin/bukkit/managers/RegionManager.java
@@ -2,10 +2,14 @@ package net.mcjukebox.plugin.bukkit.managers;
 
 import lombok.Getter;
 import net.mcjukebox.plugin.bukkit.MCJukebox;
+import net.mcjukebox.plugin.bukkit.api.JukeboxAPI;
+import net.mcjukebox.plugin.bukkit.managers.shows.ShowManager;
 import net.mcjukebox.plugin.bukkit.utils.DataUtils;
+import org.bukkit.Bukkit;
 import org.bukkit.event.Listener;
 
 import java.util.HashMap;
+import java.util.UUID;
 
 public class RegionManager implements Listener {
 
@@ -32,6 +36,23 @@ public class RegionManager implements Listener {
     }
 
     public void removeRegion(String ID){
+        ShowManager showManager = MCJukebox.getInstance().getShowManager();
+        HashMap<UUID, String> playersInRegion = MCJukebox.getInstance().getRegionListener().getPlayerInRegion();
+
+        for (HashMap.Entry<UUID, String> entry: playersInRegion.entrySet()) {
+            UUID uuid = entry.getKey();
+            String regionID = entry.getValue();
+
+            if (regionID.equals(ID)) {
+
+                if (regions.get(ID).charAt(0) == '@') {
+                    showManager.getShow(regions.get(ID)).removeMember(Bukkit.getPlayer(uuid));
+                } else {
+                    JukeboxAPI.stopMusic(Bukkit.getPlayer(uuid));
+                }
+            }
+
+        }
         regions.remove(ID);
     }
 


### PR DESCRIPTION
If the region is deleted, it is deleted from the regions HashMap. Other functions may still expect the region to exist, causing a NullPointerException when they try to access the HashMap. 

We can check to see if these values are null and stop the music as we know the region has been removed.

On the next player event after the region is removed, the music will stop.