### PR TITLE
Add Java 8 to CI and possibly speed up builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: java
+sudo: false
 jdk:
 - openjdk7
+- oraclejdk8
 deploy:
   provider: releases
   skip_cleanup: true


### PR DESCRIPTION
`sudo: false` makes Travis use a more optimized container, and may possibly speed up the build times.