### PR TITLE
Explicitly request Ubuntu Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty
 jdk:
 - openjdk7
 before_install:


### PR DESCRIPTION
Your repository's default environment at Travis CI was updated to Ubuntu Xenial 16.04

See: https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment