### PR TITLE
Add GitHub action to auto publish as a maven dependency

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,0 +1,39 @@
+# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
+# For more information see: https://github.com/actions/setup-java#apache-maven-with-a-settings-path
+
+name: Maven Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+        settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+    - name: Add Skript Dependency
+      run: sh ./scripts/installSkript.sh
+
+    - name: Clean & Install
+      run: mvn clean install --file pom.xml
+
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+
+    - name: Publish to GitHub Packages Apache Maven
+#       Only run mvn deploy when on Oliver's repo (aka. not forks)
+#       This is because the distribution repo is hardcoded in the pom file
+      if: github.repository == 'oliverdunk/JukeboxAPI'
+      run: mvn deploy -Dregistry=https://maven.pkg.github.com/${{ github.repository_owner }} -s $GITHUB_WORKSPACE/settings.xml
+      env:
+        GITHUB_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -6,3 +6,27 @@ Please see the [SpigotMC](https://www.spigotmc.org/resources/mcjukebox.16024/) r
 
 # Support
 If you need any assistance please email [support@mcjukebox.net](mailto:support@mcjukebox.net) or join our discord: [discord.gg/N3TMTCH](https://discord.gg/N3TMTCH).
+
+# Maven Repository
+If you use JukeboxAPI as a dependency for your plugin you can add it directly with the latest Jar file from the [releases page](https://github.com/oliverdunk/JukeboxAPI/releases) or as a Maven dependency.  
+
+First you need to add the GitHub Packages repository:
+
+```
+<repositories>
+    <repository>
+        <id>github</id>
+        <url>https://maven.pkg.github.com/oliverdunk/JukeboxAPI</url>
+    </repository>
+</repositories>
+```
+
+Then you need to add the dependency, with the latest version from the [packages listing](https://github.com/oliverdunk/JukeboxAPI/packages?q=com.oliverdunk.MCJukebox-plugin).
+
+```
+<dependency>
+    <groupId>com.oliverdunk.MCJukebox-plugin</groupId>
+    <artifactId>mcjukebox-plugin</artifactId>
+    <version>VERSION</version>
+</dependency>
+```

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,14 @@
         <module>plugin</module>
     </modules>
 
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub oliverdunk Apache Maven Packages</name>
+            <url>https://maven.pkg.github.com/oliverdunk/JukeboxAPI</url>
+        </repository>
+    </distributionManagement>
+
     <repositories>
         <repository>
             <id>spigot</id>


### PR DESCRIPTION
I have added a [GitHub Action](https://docs.github.com/en/actions) which will automatically build and publish the plugin as a [GitHub package](https://docs.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/using-github-packages-with-github-actions).
This will make it easier for people to implement the API into their projects via Maven. I have also added a small section in the README describing the maven repository 🎉 

The action will only run & publish when a release is made on GitHub.

All of the modules are also published to GitHub packages even though only `mcjukebox-plugin` is likely to be used.

**Caveat:** The published repository is hardcoded into the pom.xml, this should not be an issue unless this repository path changes (for example if the repo is renamed or transfered to a team) in which case it will just need a quick update 😃 
