### PR TITLE
Improve region performance

### DIFF
--- a/plugin/src/main/java/net/mcjukebox/plugin/bukkit/listeners/RegionListener.java
+++ b/plugin/src/main/java/net/mcjukebox/plugin/bukkit/listeners/RegionListener.java
@@ -52,7 +52,7 @@ public class RegionListener implements Listener{
     @EventHandler
     public void onMove(PlayerMoveEvent e){
         //Only execute if the player moves an entire block
-        if(!(e.getFrom().getX() != e.getTo().getX() || e.getFrom().getZ() != e.getTo().getZ())) return;
+        if(!((int) e.getFrom().getX() != (int) e.getTo().getX() || (int) e.getFrom().getZ() != (int) e.getTo().getZ())) return;
 
         int highestPriority = -1;
         String highestRegion = null;

--- a/plugin/src/main/java/net/mcjukebox/plugin/bukkit/listeners/RegionListener.java
+++ b/plugin/src/main/java/net/mcjukebox/plugin/bukkit/listeners/RegionListener.java
@@ -52,7 +52,7 @@ public class RegionListener implements Listener{
     @EventHandler
     public void onMove(PlayerMoveEvent e){
         //Only execute if the player moves an entire block
-        if(!((int) e.getFrom().getX() != (int) e.getTo().getX() || (int) e.getFrom().getZ() != (int) e.getTo().getZ())) return;
+        if(e.getFrom().getBlockX() == e.getTo().getBlockX() && e.getFrom().getBlockZ() == e.getTo().getBlockZ()) return;
 
         int highestPriority = -1;
         String highestRegion = null;


### PR DESCRIPTION
According to the comment, the onMove event should only execute if the player moves an entire block.
However, the getX and getZ methods return a double, so even a smal change in position would still execute the method.

By casting the locations to integers, it is ensured that it only runs for entire blocks, which can improve quite a lot performance, especially with a large number of players.