### PR TITLE
Add URL checks to prevent confusion for new users

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -26,6 +26,10 @@
             <id>vault</id>
             <url>http://nexus.hc.to/content/repositories/pub_releases</url>
         </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -37,7 +41,7 @@
         <dependency>
             <groupId>com.github.SkriptLang</groupId>
             <artifactId>Skript</artifactId>
-            <version>2.3-beta1</version>
+            <version>2.5.3</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -26,10 +26,6 @@
             <id>vault</id>
             <url>http://nexus.hc.to/content/repositories/pub_releases</url>
         </repository>
-        <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
-        </repository>
     </repositories>
 
     <dependencies>
@@ -41,7 +37,7 @@
         <dependency>
             <groupId>com.github.SkriptLang</groupId>
             <artifactId>Skript</artifactId>
-            <version>2.5.3</version>
+            <version>2.3-beta1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/plugin/src/main/java/net/mcjukebox/plugin/bukkit/commands/PlayCommand.java
+++ b/plugin/src/main/java/net/mcjukebox/plugin/bukkit/commands/PlayCommand.java
@@ -4,6 +4,7 @@ import net.mcjukebox.plugin.bukkit.api.JukeboxAPI;
 import net.mcjukebox.plugin.bukkit.api.ResourceType;
 import net.mcjukebox.plugin.bukkit.api.models.Media;
 import net.mcjukebox.plugin.bukkit.utils.MessageUtils;
+import net.mcjukebox.plugin.bukkit.utils.UrlUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -26,6 +27,15 @@ public class PlayCommand extends JukeboxCommand {
         if (args.length < 2) return false;
 
         String url = args[1];
+
+        if(!UrlUtils.isValidURI(url)) {
+            MessageUtils.sendMessage(dispatcher, "command.invalidUrl");
+            return true;
+        }
+        if(!UrlUtils.isDirectMediaFile(url)) {
+            MessageUtils.sendMessage(dispatcher, "command.unexpectedUrl");
+        }
+
         Media toPlay = new Media(type, url);
 
         if (args.length >= 3) {

--- a/plugin/src/main/java/net/mcjukebox/plugin/bukkit/commands/RegionCommand.java
+++ b/plugin/src/main/java/net/mcjukebox/plugin/bukkit/commands/RegionCommand.java
@@ -28,11 +28,12 @@ public class RegionCommand extends JukeboxCommand {
         if (args.length == 3 && args[0].equalsIgnoreCase("add")){
             String url = args[2];
             
-            if(!UrlUtils.isValidURI(url)) {
+            if (!UrlUtils.isValidURI(url)) {
                 MessageUtils.sendMessage(dispatcher, "command.invalidUrl");
                 return true;
             }
-            if(!UrlUtils.isDirectMediaFile(url)) {
+
+            if (!UrlUtils.isDirectMediaFile(url)) {
                 MessageUtils.sendMessage(dispatcher, "command.unexpectedUrl");
             }
 
@@ -43,10 +44,10 @@ public class RegionCommand extends JukeboxCommand {
 
         // region remove <id>
         if (args.length == 2 && args[0].equalsIgnoreCase("remove")){
-            if(MCJukebox.getInstance().getRegionManager().hasRegion(args[1])){
+            if (MCJukebox.getInstance().getRegionManager().hasRegion(args[1])){
                 MCJukebox.getInstance().getRegionManager().removeRegion(args[1]);
                 MessageUtils.sendMessage(dispatcher, "region.unregistered");
-            }else{
+            } else {
                 MessageUtils.sendMessage(dispatcher, "region.notregistered");
             }
             return true;

--- a/plugin/src/main/java/net/mcjukebox/plugin/bukkit/commands/RegionCommand.java
+++ b/plugin/src/main/java/net/mcjukebox/plugin/bukkit/commands/RegionCommand.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import net.mcjukebox.plugin.bukkit.MCJukebox;
 import net.mcjukebox.plugin.bukkit.managers.RegionManager;
 import net.mcjukebox.plugin.bukkit.utils.MessageUtils;
+import net.mcjukebox.plugin.bukkit.utils.UrlUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import java.util.ArrayList;
@@ -25,7 +26,17 @@ public class RegionCommand extends JukeboxCommand {
     public boolean execute(CommandSender dispatcher, String[] args) {
         // region add <id> <url>
         if (args.length == 3 && args[0].equalsIgnoreCase("add")){
-            MCJukebox.getInstance().getRegionManager().addRegion(args[1], args[2]);
+            String url = args[2];
+            
+            if(!UrlUtils.isValidURI(url)) {
+                MessageUtils.sendMessage(dispatcher, "command.invalidUrl");
+                return true;
+            }
+            if(!UrlUtils.isDirectMediaFile(url)) {
+                MessageUtils.sendMessage(dispatcher, "command.unexpectedUrl");
+            }
+
+            MCJukebox.getInstance().getRegionManager().addRegion(args[1], url);
             MessageUtils.sendMessage(dispatcher, "region.registered");
             return true;
         }

--- a/plugin/src/main/java/net/mcjukebox/plugin/bukkit/commands/RegionCommand.java
+++ b/plugin/src/main/java/net/mcjukebox/plugin/bukkit/commands/RegionCommand.java
@@ -27,14 +27,16 @@ public class RegionCommand extends JukeboxCommand {
         // region add <id> <url>
         if (args.length == 3 && args[0].equalsIgnoreCase("add")){
             String url = args[2];
-            
-            if (!UrlUtils.isValidURI(url)) {
-                MessageUtils.sendMessage(dispatcher, "command.invalidUrl");
-                return true;
-            }
 
-            if (!UrlUtils.isDirectMediaFile(url)) {
-                MessageUtils.sendMessage(dispatcher, "command.unexpectedUrl");
+            if (!url.startsWith("@")) {
+                if (!UrlUtils.isValidURI(url)) {
+                    MessageUtils.sendMessage(dispatcher, "command.invalidUrl");
+                    return true;
+                }
+
+                if (!UrlUtils.isDirectMediaFile(url)) {
+                    MessageUtils.sendMessage(dispatcher, "command.unexpectedUrl");
+                }
             }
 
             MCJukebox.getInstance().getRegionManager().addRegion(args[1], url);

--- a/plugin/src/main/java/net/mcjukebox/plugin/bukkit/managers/LangManager.java
+++ b/plugin/src/main/java/net/mcjukebox/plugin/bukkit/managers/LangManager.java
@@ -62,6 +62,8 @@ public class LangManager {
 		addDefault("event.clientDisconnect", "&cYou disconnected from our audio server.");
 
 		addDefault("command.notOnline", "&c[user] is not currently online.");
+		addDefault("command.invalidUrl", "&cThe URL you entered is not valid. Please make sure that you entered the complete URL.");
+		addDefault("command.unexpectedUrl", "&6The URL you entered appears to be unsupported. Only direct file URLs are supported. Links to Spotify, YouTube, SoundCloud, etc. won't work.");
 	}
 
 	/**

--- a/plugin/src/main/java/net/mcjukebox/plugin/bukkit/managers/LangManager.java
+++ b/plugin/src/main/java/net/mcjukebox/plugin/bukkit/managers/LangManager.java
@@ -63,7 +63,7 @@ public class LangManager {
 
 		addDefault("command.notOnline", "&c[user] is not currently online.");
 		addDefault("command.invalidUrl", "&cThe URL you entered is not valid. Please make sure that you entered the complete URL.");
-		addDefault("command.unexpectedUrl", "&6The URL you entered appears to be unsupported. Only direct file URLs are supported. Links to Spotify, YouTube, SoundCloud, etc. won't work.");
+		addDefault("command.unexpectedUrl", "&6Warning: The URL you provided does not have a recognised file extension and may fail to play. Links to files hosted on services like Spotify, YouTube and SoundCloud are unsupported.");
 	}
 
 	/**

--- a/plugin/src/main/java/net/mcjukebox/plugin/bukkit/utils/UrlUtils.java
+++ b/plugin/src/main/java/net/mcjukebox/plugin/bukkit/utils/UrlUtils.java
@@ -2,7 +2,6 @@ package net.mcjukebox.plugin.bukkit.utils;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Arrays;
 
 public class UrlUtils {
     private static String[] supportedFiles = {
@@ -18,17 +17,14 @@ public class UrlUtils {
     {
         URI uri;
         try {
-            uri = getUrlWithoutParameters(url);
-            if (uri == null) {
-                return false;
-            }
+            uri = new URI(url);
         } catch (URISyntaxException e) {
             return false;
         }
 
-        if(!uri.isAbsolute()) return false;
-
-        if (!uri.getScheme().equals("http") && !uri.getScheme().equals("https")) return false;
+        if(!uri.isAbsolute() || (!uri.getScheme().equals("http") && !uri.getScheme().equals("https"))) {
+            return false;
+        }
 
         return true;
     }
@@ -36,11 +32,12 @@ public class UrlUtils {
     public static boolean isDirectMediaFile(String url) {
         URI uri;
         try {
-            uri = getUrlWithoutParameters(url);
-            if (uri == null) {
-                return false;
-            }
+            uri = new URI(url);
         } catch (URISyntaxException e) {
+            return false;
+        }
+
+        if (uri.getPath() == null) {
             return false;
         }
 
@@ -51,14 +48,5 @@ public class UrlUtils {
             }
         }
         return false;
-    }
-
-    private static URI getUrlWithoutParameters(String url) throws URISyntaxException {
-        URI uri = new URI(url);
-        return new URI(uri.getScheme(),
-                uri.getAuthority(),
-                uri.getPath(),
-                null, // Ignore the query part of the input url
-                uri.getFragment());
     }
 }

--- a/plugin/src/main/java/net/mcjukebox/plugin/bukkit/utils/UrlUtils.java
+++ b/plugin/src/main/java/net/mcjukebox/plugin/bukkit/utils/UrlUtils.java
@@ -1,0 +1,64 @@
+package net.mcjukebox.plugin.bukkit.utils;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+
+public class UrlUtils {
+    private static String[] supportedFiles = {
+            "mp3",
+            "ogg",
+            "wav",
+            "webm",
+            "flac",
+            "adts"
+    };
+
+    public static boolean isValidURI(String url)
+    {
+        URI uri;
+        try {
+            uri = getUrlWithoutParameters(url);
+            if (uri == null) {
+                return false;
+            }
+        } catch (URISyntaxException e) {
+            return false;
+        }
+
+        if(!uri.isAbsolute()) return false;
+
+        if (!uri.getScheme().equals("http") && !uri.getScheme().equals("https")) return false;
+
+        return true;
+    }
+
+    public static boolean isDirectMediaFile(String url) {
+        URI uri;
+        try {
+            uri = getUrlWithoutParameters(url);
+            if (uri == null) {
+                return false;
+            }
+        } catch (URISyntaxException e) {
+            return false;
+        }
+
+        String path = uri.getPath();
+        for (String fileType: supportedFiles) {
+            if (path.endsWith(fileType)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static URI getUrlWithoutParameters(String url) throws URISyntaxException {
+        URI uri = new URI(url);
+        return new URI(uri.getScheme(),
+                uri.getAuthority(),
+                uri.getPath(),
+                null, // Ignore the query part of the input url
+                uri.getFragment());
+    }
+}

--- a/plugin/src/main/java/net/mcjukebox/plugin/bukkit/utils/UrlUtils.java
+++ b/plugin/src/main/java/net/mcjukebox/plugin/bukkit/utils/UrlUtils.java
@@ -46,7 +46,7 @@ public class UrlUtils {
 
         String path = uri.getPath();
         for (String fileType: supportedFiles) {
-            if (path.endsWith(fileType)) {
+            if (path.endsWith("."+fileType)) {
                 return true;
             }
         }


### PR DESCRIPTION
I noticed in the Discord that a lot of new users had trouble with understanding which types of URLs are supported.
This PR adds some checks when the user wants to play a sound, and shows a warning when the URL appears to be incorrect.

It:
- Checks if the URL is valid at all and stops execution if it is not (for example, not http(s), relative path, etc.)
- Checks if the URL is a direct link to an audio file. If it appears not to be, it shows a warning but still executes the command, in case the user has some weird URL that is direct, but does not appear to be.

URL without an extension:
![Screenshot 2021-03-30 at 11 50 08](https://user-images.githubusercontent.com/2168623/112970041-158d7200-914e-11eb-80eb-5a5cd804d13e.png)

Invalid URL (No schema):
![Screenshot 2021-03-30 at 11 51 00](https://user-images.githubusercontent.com/2168623/112970169-348c0400-914e-11eb-9dc4-4595102843b8.png)

YouTube URL:
![Screenshot 2021-03-30 at 11 51 42](https://user-images.githubusercontent.com/2168623/112970267-4e2d4b80-914e-11eb-8de3-d94340a46bff.png)

I think this does not only make the plugin easier for new users, but that it can also prevent some easy to make mistakes for experienced users.